### PR TITLE
Update Action.php

### DIFF
--- a/src/Action.php
+++ b/src/Action.php
@@ -16,5 +16,7 @@ abstract class Action
     public function setRecord(Record $record)
     {
         $this->record = $record;
+
+        return $this;
     }
 }

--- a/src/Action.php
+++ b/src/Action.php
@@ -13,7 +13,7 @@ abstract class Action
     /**
      * @param Record $record
      */
-    public function setRecord(Record $record)
+    public function setRecord(Record $record): self
     {
         $this->record = $record;
 

--- a/src/Action.php
+++ b/src/Action.php
@@ -13,7 +13,7 @@ abstract class Action
     /**
      * @param Record $record
      */
-    public function setRecord(Record $record): self
+    public function setRecord(Record $record)
     {
         $this->record = $record;
 


### PR DESCRIPTION
Return $this in the setRecord method to allow chaining.

Use case: 

When skipping steps and using an action as the initial state, it makes sense to allow calling other actions;

E.g

```php
        $payer = new MakePayment();
        $pledger = new MakePledge();

        return match (count($steps)) {
            1 => SelectCampaign::class,
            2 => $steps[0] === '2' ? PaymentWelcome::class : PledgeWelcome::class,
            3 => $steps[0] === '2' ? $payer->setRecord($this->record)->run() : $pledger->setRecord($this->record)->run(),
            default => Home::class
        };

```